### PR TITLE
remove connections from block explorer header

### DIFF
--- a/public/views/includes/header.html
+++ b/public/views/includes/header.html
@@ -37,7 +37,9 @@
         </div>
         &nbsp; &middot;
         <strong>Last Block</strong> {{totalBlocks || info.blocks}} &middot;
-        <strong>Supply</strong> {{info.moneysupply}} RDD
+        <span data-ng-init="getStatus('Info')">
+          <strong>Supply</strong> {{info.moneysupply}} RDD
+        </span>
       </div>
       </li>
       <li>

--- a/public/views/includes/header.html
+++ b/public/views/includes/header.html
@@ -37,10 +37,7 @@
         </div>
         &nbsp; &middot;
         <strong>Last Block</strong> {{totalBlocks || info.blocks}} &middot;
-        <strong>Supply</strong> {{info.moneysupply}} RDD &middot;
-        <span data-ng-init="getStatus('Info')">
-          <strong>Conn</strong> {{info.connections}}
-        </span>
+        <strong>Supply</strong> {{info.moneysupply}} RDD
       </div>
       </li>
       <li>


### PR DESCRIPTION
Conn # is unnecessary clutter as it is available in the Status tab and not something the average user cares about.
